### PR TITLE
Add Dockerfile and run instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY contracts ./contracts
+COPY src ./src
+COPY .env ./
+
+ENV PYTHONPATH "${PYTHONPATH}:/app"
+
+CMD [ "python", "src/main.py" ]
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # defi-arbitrage-bot
+
+## Run Dev:
+- Set up `NODE_URL=YOUR_NODE_URL` in .env
+- pip3 install -r requirements.txt
+- export PYTHONPATH="${PYTHONPATH}:/path/to/repo"
+
+## Run Container:
+- Set up `NODE_URL=YOUR_NODE_URL` in .env
+- docker built . -t defi
+- docker run -it defi
+


### PR DESCRIPTION
#### Intent
- Adds a Dockerfile which can be used to build a container for the repo & run it
- Adds instructions to README, both for containerized and non-containerized versions

#### Description
Dockerfile can be used to throw this up on AWS App Runner, for example, or EC2. 

#### Building
<img width="600" alt="Screenshot 2023-12-03 at 9 51 46 PM" src="https://github.com/AntonJiang/defi-arbitrage-bot/assets/46757909/e598d09d-ea9f-49b1-a950-f365e5791c1a">

#### Running
<img width="500" alt="Screenshot 2023-12-03 at 9 53 12 PM" src="https://github.com/AntonJiang/defi-arbitrage-bot/assets/46757909/14a073fd-68cd-4f64-8f21-f53057a0812c">
